### PR TITLE
Add GOG.Galaxy and bump to v1.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.13] - 2026-07-30
+
+### Added
+- `GOG.Galaxy` to `media` category
+
 ## [1.1.12] - 2026-07-25
 
 ### Added

--- a/winget-packages.yml
+++ b/winget-packages.yml
@@ -67,6 +67,7 @@ packages:
     - GuinpinSoft.MakeMKV # MakeMKV disc ripper
     - Gyan.FFmpeg # FFmpeg multimedia framework
     - Valve.Steam # Steam gaming platform
+    - GOG.Galaxy
     - martinrotter.RSSGuard5
 
   # ── Data science & ML ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add `GOG.Galaxy` to the `media` category in `winget-packages.yml`
- Document the change as patch release **1.1.13** in `CHANGELOG.md`

## Test plan
- [ ] Confirm `GOG.Galaxy` appears under the media section of `winget-packages.yml`
- [ ] Confirm CHANGELOG has a new `[1.1.13]` entry dated 2026-07-30
- [ ] After merge, regenerate-config workflow updates `configuration.dsc.yaml` as expected