### PR TITLE
Add Herdr.Herdr.Preview and bump to v1.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.16] - 2026-09-05
+
+### Added
+- `Herdr.Herdr.Preview` to `development` category
+
 ## [1.1.15] - 2026-08-24
 
 ### Added

--- a/winget-packages.yml
+++ b/winget-packages.yml
@@ -29,6 +29,7 @@ packages:
     - Anthropic.ClaudeCode
     - Google.Antigravity
     - xAI.GrokBuild # Grok Build CLI agent
+    - Herdr.Herdr.Preview # herdr agent runtime (preview)
     - Google.AndroidStudio
     - Hashicorp.TerraformLanguageServer
 


### PR DESCRIPTION
## Summary
- Add `Herdr.Herdr.Preview` to the `development` category in `winget-packages.yml`
- Document the change as patch release **1.1.16** in `CHANGELOG.md`

## Test plan
- [ ] Confirm `Herdr.Herdr.Preview` appears under the development section of `winget-packages.yml`
- [ ] Confirm CHANGELOG has a new `[1.1.16]` entry dated 2026-09-05
- [ ] Confirm Validate WinGet Configuration CI is green
- [ ] After merge, regenerate-config workflow updates `configuration.dsc.yaml` as expected
- [ ] After merge, release workflow publishes GitHub release `v1.1.16`